### PR TITLE
Add core unit tests and CI test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ vet:
 test:
 	go test -v ./...
 
+.PHONY: test-ci
+test-ci:
+	./scripts/run-tests.sh
+
 deps:
 	go mod download
 	go mod tidy

--- a/pkg/collector/ping_test.go
+++ b/pkg/collector/ping_test.go
@@ -1,0 +1,30 @@
+package collector
+
+import "testing"
+
+func TestCalculateMean(t *testing.T) {
+	pc := NewPingCollector(nil)
+	values := []float64{10, 20, 30}
+	if m := pc.calculateMean(values); m != 20 {
+		t.Fatalf("expected 20 got %v", m)
+	}
+}
+
+func TestCalculateJitter(t *testing.T) {
+	pc := NewPingCollector(nil)
+	latencies := []float64{10, 20, 30, 20}
+	jitter := pc.calculateJitter(latencies)
+	if jitter <= 0 {
+		t.Fatalf("expected positive jitter got %v", jitter)
+	}
+}
+
+func TestLANSupportsInterface(t *testing.T) {
+	lc := NewLANCollector(nil)
+	if !lc.SupportsInterface("eth0") {
+		t.Fatalf("expected eth0 supported")
+	}
+	if lc.SupportsInterface("wwan0") {
+		t.Fatalf("did not expect wwan0 supported")
+	}
+}

--- a/pkg/controller/mwan3_test.go
+++ b/pkg/controller/mwan3_test.go
@@ -1,0 +1,42 @@
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/markus-lassfolk/rutos-starlink-failover/pkg/logx"
+)
+
+func TestParseMwan3Config(t *testing.T) {
+	sample := "mwan3.wan1.interface='wan'\n" +
+		"mwan3.wan2.interface='wan2'\n" +
+		"mwan3.wan2.enabled='0'\n"
+	c := NewController(Config{UseMwan3: true}, logx.New("debug"))
+	members, err := c.parseMwan3Config(sample)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+	found := map[string]bool{}
+	for _, m := range members {
+		found[m.Name] = true
+	}
+	if !found["wan1"] || !found["wan2"] {
+		t.Fatalf("members not parsed correctly: %v", members)
+	}
+}
+
+func TestSetPrimaryCooldown(t *testing.T) {
+	logger := logx.New("debug")
+	c := NewController(Config{UseMwan3: false, DryRun: true, CooldownS: 10}, logger)
+	ctx := context.Background()
+	m := Member{Name: "wan", Interface: "wan"}
+	_ = c.SetPrimary(ctx, m)
+	c.lastChange = time.Now()
+	if err := c.SetPrimary(ctx, m); err == nil {
+		t.Fatalf("expected cooldown error")
+	}
+}

--- a/pkg/decision/engine_test.go
+++ b/pkg/decision/engine_test.go
@@ -1,0 +1,61 @@
+package decision
+
+import (
+	"github.com/markus-lassfolk/rutos-starlink-failover/pkg/collector"
+	"github.com/markus-lassfolk/rutos-starlink-failover/pkg/logx"
+	"testing"
+)
+
+func TestScoreLatency(t *testing.T) {
+	logger := logx.New("debug")
+	eng := NewEngine(Config{}, *logger, nil, nil, nil, nil)
+
+	cases := []struct {
+		latency  float64
+		expected float64
+	}{
+		{25, 100},    // excellent
+		{100, 93.33}, // good
+		{300, 73.33}, // fair
+		{700, 48},    // poor
+	}
+
+	for _, c := range cases {
+		got := eng.scoreLatency(c.latency)
+		if (got-c.expected) > 0.1 || (c.expected-got) > 0.1 {
+			t.Fatalf("latency %v expected %.2f got %.2f", c.latency, c.expected, got)
+		}
+	}
+}
+
+func TestCalculateInstantScoreClassPreference(t *testing.T) {
+	cfg := Config{}
+	logger := logx.New("debug")
+	eng := NewEngine(cfg, *logger, nil, nil, nil, nil)
+
+	lat := 100.0
+	loss := 2.0
+	jit := 10.0
+	metrics := collector.Metrics{LatencyMs: &lat, PacketLossPct: &loss, JitterMs: &jit}
+
+	starScore := eng.calculateInstantScore(metrics, collector.Member{Class: "starlink"})
+	cellScore := eng.calculateInstantScore(metrics, collector.Member{Class: "cellular"})
+
+	if starScore <= cellScore {
+		t.Fatalf("expected starlink score > cellular: %v vs %v", starScore, cellScore)
+	}
+}
+
+func TestPredictiveSwitch(t *testing.T) {
+	cfg := Config{EnablePredictive: true, PredictThreshold: 5}
+	logger := logx.New("debug")
+	eng := NewEngine(cfg, *logger, nil, nil, nil, nil)
+
+	eng.currentPrimary = "wan1"
+	eng.members["wan1"] = &MemberState{Score: Score{EWMA: 80, Instant: 70}, Eligible: true}
+	eng.members["wan2"] = &MemberState{Score: Score{Final: 90}, Eligible: true}
+
+	if !eng.shouldPreemptiveSwitch("wan2") {
+		t.Fatalf("expected predictive switch")
+	}
+}

--- a/pkg/uci/config_test.go
+++ b/pkg/uci/config_test.go
@@ -1,0 +1,60 @@
+package uci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadDefaultsWhenUCINotPresent(t *testing.T) {
+	t.Setenv("PATH", "")
+	loader := NewLoader("/etc/config/starfail")
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if !cfg.Main.Enable || cfg.Main.PollIntervalMs != 1500 {
+		t.Fatalf("unexpected defaults: %+v", cfg.Main)
+	}
+}
+
+func TestLoadMainAndMembersFromUCI(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "uci")
+	content := `#!/bin/sh
+if [ "$1" = show ] && [ "$2" = starfail.main ]; then
+  echo "starfail.main.enable='0'"
+  echo "starfail.main.use_mwan3='0'"
+  echo "starfail.main.poll_interval_ms='2000'"
+elif [ "$1" = show ] && [ "$2" = starfail ]; then
+  echo "starfail.@member[0].class='cellular'"
+  echo "starfail.@member[0].weight='60'"
+  echo "starfail.@member[1].class='wifi'"
+fi
+`
+	if err := os.WriteFile(script, []byte(content), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	loader := NewLoader("/etc/config/starfail")
+	cfg, err := loader.Load()
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if cfg.Main.Enable || cfg.Main.UseMwan3 || cfg.Main.PollIntervalMs != 2000 {
+		t.Fatalf("uci overrides not applied: %+v", cfg.Main)
+	}
+	if len(cfg.Members) != 2 || cfg.Members[0].Class != "cellular" || cfg.Members[0].Weight != 60 {
+		t.Fatalf("member parsing failed: %+v", cfg.Members)
+	}
+}
+
+func TestValidateMainInvalidPollInterval(t *testing.T) {
+	loader := NewLoader("/etc/config/starfail")
+	cfg := loader.getDefaultConfig()
+	cfg.Main.PollIntervalMs = 100
+	if err := loader.Validate(cfg); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+echo "Running unit tests"
+go test ./...


### PR DESCRIPTION
## Summary
- add unit tests for decision engine scoring and predictive switching
- test UCI config loader and member parsing
- cover controller cooldown logic and ping collector helpers
- add `test-ci` Makefile target and script

## Testing
- `make test-ci`


------
https://chatgpt.com/codex/tasks/task_b_689d8d888c908326ab1c9e7335ea743d