### PR TITLE
Compute jitter from latency history

### DIFF
--- a/pkg/collector/base_test.go
+++ b/pkg/collector/base_test.go
@@ -1,0 +1,39 @@
+package collector
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalculateJitter(t *testing.T) {
+	bc := NewBaseCollector(0, nil)
+	member := "test-member"
+
+	if j := bc.calculateJitter(member, 100); j != 0 {
+		t.Fatalf("expected jitter 0 with single sample, got %f", j)
+	}
+
+	if j := bc.calculateJitter(member, 110); math.Abs(j-5) > 0.0001 {
+		t.Fatalf("expected jitter ~5, got %f", j)
+	}
+
+	if j := bc.calculateJitter(member, 90); math.Abs(j-math.Sqrt(200.0/3.0)) > 0.0001 {
+		t.Fatalf("expected jitter %.4f, got %f", math.Sqrt(200.0/3.0), j)
+	}
+}
+
+func TestJitterHistoryLimit(t *testing.T) {
+	bc := NewBaseCollector(0, nil)
+	bc.historySize = 2
+	member := "test-member"
+
+	bc.calculateJitter(member, 100)
+	bc.calculateJitter(member, 110)
+	if j := bc.calculateJitter(member, 150); math.Abs(j-20) > 0.0001 {
+		t.Fatalf("expected jitter 20 with limited history, got %f", j)
+	}
+
+	if len(bc.latencyHistory[member]) != 2 {
+		t.Fatalf("expected history size 2, got %d", len(bc.latencyHistory[member]))
+	}
+}


### PR DESCRIPTION
## Summary
- track per-member latency history in BaseCollector and compute jitter as standard deviation
- add unit tests covering jitter calculation and history trimming

## Testing
- `go test ./pkg/collector -run TestCalculateJitter -count=1`
- `go test ./...` *(fails: updates to go.mod needed; to update it: go mod tidy)*

------
https://chatgpt.com/codex/tasks/task_b_689d8f5225dc8326924d6356283a2ce0