### PR TITLE
Add thread-safe member management

### DIFF
--- a/cmd/starfaild/main.go
+++ b/cmd/starfaild/main.go
@@ -171,7 +171,10 @@ func main() {
 	}
 
 	// Set discovered members in controller
-	ctrl.SetMembers(members)
+	if err := ctrl.SetMembers(members); err != nil {
+		logger.Error("Failed to set members", "error", err)
+		os.Exit(1)
+	}
 
 	// Initialize ubus server
 	ubusServer := ubus.NewServer(ctrl, decisionEngine, telemetry, logger)
@@ -299,10 +302,13 @@ func runMainLoop(ctx context.Context, cfg *uci.Config, engine *decision.Engine, 
 				})
 			} else {
 				// Update controller with new members
-				ctrl.SetMembers(newMembers)
-				logger.Debug("Member discovery refreshed", map[string]interface{}{
-					"member_count": len(newMembers),
-				})
+				if err := ctrl.SetMembers(newMembers); err != nil {
+					logger.Error("Failed to set members", map[string]interface{}{"error": err.Error()})
+				} else {
+					logger.Debug("Member discovery refreshed", map[string]interface{}{
+						"member_count": len(newMembers),
+					})
+				}
 			}
 
 		case <-cleanupTicker.C:

--- a/pkg/health/server.go
+++ b/pkg/health/server.go
@@ -250,10 +250,7 @@ func (s *Server) getDetailedHealthStatus() HealthStatus {
 
 // getMemberHealth returns health information for all members
 func (s *Server) getMemberHealth() []MemberHealth {
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return []MemberHealth{}
-	}
+	members := s.controller.GetMembers()
 	activeMember, err := s.controller.GetActiveMember()
 	if err != nil {
 		activeMember = nil
@@ -310,10 +307,7 @@ func (s *Server) getMemberHealth() []MemberHealth {
 
 // getStatistics returns system statistics
 func (s *Server) getStatistics() Statistics {
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return Statistics{}
-	}
+	members := s.controller.GetMembers()
 	activeMember, err := s.controller.GetActiveMember()
 	if err != nil {
 		activeMember = nil

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -277,10 +277,7 @@ func (s *Server) UpdateMetrics() {
 
 // updateMemberMetrics updates member-related metrics
 func (s *Server) updateMemberMetrics() {
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return
-	}
+	members := s.controller.GetMembers()
 	activeMember, err := s.controller.GetActiveMember()
 	if err != nil {
 		activeMember = nil
@@ -356,10 +353,7 @@ func (s *Server) updateMemberMetrics() {
 
 // updateTelemetryMetrics updates telemetry-related metrics
 func (s *Server) updateTelemetryMetrics() {
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return
-	}
+	members := s.controller.GetMembers()
 
 	// Update sample counts
 	for _, member := range members {
@@ -371,6 +365,9 @@ func (s *Server) updateTelemetryMetrics() {
 
 	// Update event counts
 	events, err := s.store.GetEvents(time.Now().Add(-time.Hour), 1000)
+	if err != nil {
+		return
+	}
 	eventCounts := make(map[string]int)
 	for _, event := range events {
 		eventCounts[event.Type]++

--- a/pkg/testing/framework.go
+++ b/pkg/testing/framework.go
@@ -157,7 +157,9 @@ func (tf *TestFramework) MockController() *controller.Controller {
 	if err != nil {
 		tf.t.Fatalf("Failed to create controller: %v", err)
 	}
-	ctrl.SetMembers(tf.MockMembers())
+	if err := ctrl.SetMembers(tf.MockMembers()); err != nil {
+		tf.t.Fatalf("Failed to set members: %v", err)
+	}
 	return ctrl
 }
 

--- a/pkg/ubus/server.go
+++ b/pkg/ubus/server.go
@@ -193,9 +193,9 @@ func (s *Server) handleActionWrapper(ctx context.Context, data json.RawMessage) 
 
 // StatusResponse represents the response for status queries
 type StatusResponse struct {
-	ActiveMember    *pkg.Member     `json:"active_member"`
-	Members         []pkg.Member    `json:"members"`
-	LastSwitch      *pkg.Event      `json:"last_switch,omitempty"`
+	ActiveMember    *pkg.Member       `json:"active_member"`
+	Members         []pkg.Member      `json:"members"`
+	LastSwitch      *pkg.Event        `json:"last_switch,omitempty"`
 	Uptime          time.Duration     `json:"uptime"`
 	DecisionState   string            `json:"decision_state"`
 	ControllerState string            `json:"controller_state"`
@@ -211,10 +211,7 @@ func (s *Server) GetStatus() (*StatusResponse, error) {
 	if err != nil {
 		activeMember = nil
 	}
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		members = []*pkg.Member{}
-	}
+	members := s.controller.GetMembers()
 
 	// Get last switch event
 	var lastSwitch *pkg.Event
@@ -265,8 +262,8 @@ type MemberInfo struct {
 	Member  pkg.Member   `json:"member"`
 	Metrics *pkg.Metrics `json:"metrics,omitempty"`
 	Score   *pkg.Score   `json:"score,omitempty"`
-	State   string         `json:"state"`
-	Status  string         `json:"status"`
+	State   string       `json:"state"`
+	Status  string       `json:"status"`
 }
 
 // GetMembers returns detailed information about all members
@@ -274,10 +271,7 @@ func (s *Server) GetMembers() (*MembersResponse, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return &MembersResponse{Members: []MemberInfo{}}, nil
-	}
+	members := s.controller.GetMembers()
 	memberInfos := make([]MemberInfo, len(members))
 
 	for i, member := range members {
@@ -314,9 +308,9 @@ func (s *Server) GetMembers() (*MembersResponse, error) {
 
 // MetricsResponse represents the response for metrics queries
 type MetricsResponse struct {
-	Member  string         `json:"member"`
+	Member  string          `json:"member"`
 	Samples []*telem.Sample `json:"samples"`
-	Period  time.Duration  `json:"period"`
+	Period  time.Duration   `json:"period"`
 }
 
 // GetMetrics returns historical metrics for a specific member
@@ -336,7 +330,7 @@ func (s *Server) GetMetrics(memberName string, hours int) (*MetricsResponse, err
 
 // EventsResponse represents the response for events queries
 type EventsResponse struct {
-	Events []*pkg.Event `json:"events"`
+	Events []*pkg.Event  `json:"events"`
 	Period time.Duration `json:"period"`
 }
 
@@ -373,14 +367,8 @@ func (s *Server) Failover(req *FailoverRequest) (*FailoverResponse, error) {
 	defer s.mu.Unlock()
 
 	// Validate target member exists
-	members, err := s.controller.GetMembers()
-	if err != nil {
-		return &FailoverResponse{
-			Success: false,
-			Message: fmt.Sprintf("Failed to get members: %v", err),
-		}, nil
-	}
-	
+	members := s.controller.GetMembers()
+
 	var targetMember *pkg.Member
 	for _, member := range members {
 		if member.Name == req.TargetMember {
@@ -408,7 +396,7 @@ func (s *Server) Failover(req *FailoverRequest) (*FailoverResponse, error) {
 
 	// Perform the failover (placeholder)
 	// TODO: Implement SwitchToMember method
-	err = fmt.Errorf("SwitchToMember not implemented")
+	err := fmt.Errorf("SwitchToMember not implemented")
 	if err != nil {
 		return &FailoverResponse{
 			Success: false,


### PR DESCRIPTION
## Summary
- Track controller members and guard access with RWMutex
- Validate and store member lists via new `SetMembers`
- Update consumers and tests for new `GetMembers` signature

## Testing
- `go test ./...` *(fails: s.decision.RecheckMember undefined; s.logger.SetLevel not used as value; GetTelemetry undefined; and other compile errors in pkg/ubus and pkg/testing packages)*

------
https://chatgpt.com/codex/tasks/task_b_689d8f2a21908326952483cb5d2d5ac1